### PR TITLE
Bot added setcharacter() and include dungeon stats

### DIFF
--- a/cogs/constants.py
+++ b/cogs/constants.py
@@ -1,4 +1,5 @@
 API_URL = "https://raider.io/api/v1/characters/profile?region={}&realm={}&name={}&fields={}"
+API_FIELDS = ['mythic_plus_scores', 'mythic_plus_ranks', 'mythic_plus_best_runs', 'mythic_plus_alternate_runs']
 
 DEFAULT_SETCHARACTERS_JSON = {'example_discord_unique_id': {'region': 'us', 'realm': 'stormrage', 'character_name': 'sample_name'}}
 

--- a/cogs/constants.py
+++ b/cogs/constants.py
@@ -1,5 +1,7 @@
 API_URL = "https://raider.io/api/v1/characters/profile?region={}&realm={}&name={}&fields={}"
 
+DEFAULT_SETCHARACTERS_JSON = {'example_discord_unique_id': {'region': 'us', 'realm': 'stormrage', 'character_name': 'sample_name'}}
+
 spec_ids = {
 	'Death Knight': {
 		'Blood': {

--- a/cogs/constants.py
+++ b/cogs/constants.py
@@ -2,63 +2,171 @@ API_URL = "https://raider.io/api/v1/characters/profile?region={}&realm={}&name={
 
 spec_ids = {
 	'Death Knight': {
-		'Blood': 250,
-		'Frost': 251,
-		'Unholy': 252
+		'Blood': {
+			'id': 0,
+			'uid': 250
+		},
+		'Frost': {
+			'id': 1,
+			'uid': 251
+		},
+		'Unholy': {
+			'id': 2,
+			'uid': 252
+		}
 	},
 	'Demon Hunter': {
-		'Havoc': 577,
-		'Vengeance': 581
+		'Havoc': {
+			'id': 0,
+			'uid': 577
+		},
+		'Vengeance': {
+			'id': 1,
+			'uid': 581
+		}
 	},
 	'Druid': {
-		'Balance': 102,
-		'Feral': 103,
-		'Guardian': 104,
-		'Restoration': 105
+		'Balance': {
+			'id': 0,
+			'uid': 102
+		},
+		'Feral': {
+			'id': 1,
+			'uid': 103
+		},
+		'Guardian': {
+			'id': 2,
+			'uid': 104
+		},
+		'Restoration': {
+			'id': 3,
+			'uid': 105
+		}
 	},
 	'Hunter': {
-		'Beast Mastery': 253,
-		'Marksmanship': 254,
-		'Survival': 255
+		'Beast Mastery': {
+			'id': 0,
+			'uid': 253
+		},
+		'Marksmanship': {
+			'id': 1,
+			'uid': 254
+		},
+		'Survival': {
+			'id': 2,
+			'uid': 255
+		}
 	},
 	'Mage': {
-		'Arcane': 62,
-		'Fire': 63,
-		'Frost': 64
+		'Arcane': {
+			'id': 0,
+			'uid': 62
+		},
+		'Fire': {
+			'id': 1,
+			'uid': 63
+		},
+		'Frost': {
+			'id': 2,
+			'uid': 64
+		}
 	},
 	'Monk': {
-		'Brewmaster': 268,
-		'Windwalker': 269,
-		'Mistweaver': 270
+		'Brewmaster': {
+			'id': 0,
+			'uid': 268
+		},
+		'Windwalker': {
+			'id': 1,
+			'uid': 269
+		},
+		'Mistweaver': {
+			'id': 2,
+			'uid': 270
+		}
 	},
 	'Paladin': {
-		'Holy': 65,
-		'Protection': 66,
-		'Retribution': 70
+		'Holy': {
+			'id': 0,
+			'uid': 65
+		},
+		'Protection': {
+			'id': 1,
+			'uid': 66
+		},
+		'Retribution': {
+			'id': 2,
+			'uid': 70
+		}
 	},
 	'Priest': {
-		'Discipline': 256,
-		'Holy': 257,
-		'Shadow': 258
+		'Discipline': {
+			'id': 0,
+			'uid': 256
+		},
+		'Holy': {
+			'id': 1,
+			'uid': 257
+		},
+		'Shadow': {
+			'id': 2,
+			'uid': 258
+		}
 	},
 	'Rogue': {
-		'Assassination': 259,
-		'Outlaw': 260,
-		'Subtlety': 261
+		'Assassination': {
+			'id': 0,
+			'uid': 259
+		},
+		'Outlaw': {
+			'id': 1,
+			'uid': 260
+		},
+		'Subtlety': {
+			'id': 2,
+			'uid': 261
+		}
 	},
 	'Shaman': {
-		'Elemental': 262,
-		'Enhancement': 263,
-		'Restoration': 264
+		'Elemental': {
+			'id': 0,
+			'uid': 262
+		},
+		'Enhancement': {
+			'id': 1,
+			'uid': 263
+		},
+		'Restoration': {
+			'id': 2,
+			'uid': 264
+		}
 	},
 	'Warlock': {
-		'Affliction': 265,
-		'Demonology': 266,
-		'Destruction': 267
+		'Affliction': {
+			'id': 0,
+			'uid': 265
+		},
+		'Demonology': {
+			'id': 1,
+			'uid': 266
+		},
+		'Destruction': {
+			'id': 2,
+			'uid': 267
+		}
 	},
 	'Warrior': {
-		'Arms': 71,
-		'Fury': 72,
-		'Protection': 73
+		'Arms': {
+			'id': 0,
+			'uid': 71
+		},
+		'Fury': {
+			'id': 1,
+			'uid': 72
+		},
+		'Protection': {
+			'id': 2,
+			'uid': 73
+		}
 	}
 }

--- a/cogs/individuals.py
+++ b/cogs/individuals.py
@@ -1,6 +1,7 @@
 import discord
 import requests
 import os
+import json
 
 from . import constants
 from discord.ext import commands
@@ -20,29 +21,35 @@ class Individuals(commands.Cog):
         return char_role
 
     @commands.command()
-    async def score(self, ctx, *, args):
+    async def score(self, ctx, *args):
         """
         Sends out the score of the player
         """
 
         region, realm, character_name = "", "", ""
-        api_fields = ['mythic_plus_scores', 'mythic_plus_ranks', 'mythic_plus_best_runs', 'mythic_plus_alternate_runs']
+        api_fields = constants.API_FIELDS
 
-        if args == "":
+        if len(args) == 0:
             if os.path.isfile("./data/setcharacters.json"):
                 with open('./data/setcharacters.json', 'r') as f:
                     setcharacters_json = json.load(f)
 
                     if not str(ctx.message.author.id) in setcharacters_json.keys():
                         await ctx.send(f'You have not yet set a character to your discord account. To do so, type `~setcharacter <character>`')
-                        break
+                        return
 
-                    region = setcharacters_json[str(ctx.message.author.id)][0]
-                    realm = setcharacters_json[str(ctx.message.author.id)][1]
-                    character_name = setcharacters_json[str(ctx.message.author.id)][2]
+                    region = setcharacters_json[str(ctx.message.author.id)]['region']
+                    realm = setcharacters_json[str(ctx.message.author.id)]['realm']
+                    character_name = setcharacters_json[str(ctx.message.author.id)]['character_name']
             else:
                 await ctx.send(f'You have not yet set a character to your discord account. To do so, type `~setcharacter <character>`')
-                break
+                return
+        elif len(args) >= 1:
+            try:
+                assert len(args) <= 1, "`score` command must follow format `~score <character>`!"
+            except AssertionError:
+                await ctx.send("`score` command must follow format `~score <character>`!")
+                raise
         else:
         	character_split = args.split("/")
 
@@ -170,6 +177,8 @@ class Individuals(commands.Cog):
         Sets a default character for the discord user
         """
 
+        api_fields = constants.API_FIELDS
+
         if args == "":
             try:
                 assert args != "", "`<character>` field must not be empty`!"
@@ -196,7 +205,6 @@ class Individuals(commands.Cog):
             with open('./data/setcharacters.json', 'a') as dumpfile:
                 json.dump(constants.DEFAULT_SETCHARACTERS_JSON, dumpfile, indent=4)
 
-
         with open('./data/setcharacters.json', 'r') as f:
             setcharacters_json = json.load(f)
 
@@ -219,7 +227,7 @@ class Individuals(commands.Cog):
             raise
         
         setcharacters_json[str(ctx.message.author.id)] = {'region': character_split[0], 'realm': character_split[1], 'character_name': character_split[2]}
-        with open(constants.API_URL, 'w') as f:
+        with open('./data/setcharacters.json', 'w') as f:
             json.dump(setcharacters_json, f)
         await ctx.send(f'{ctx.message.author.mention}, character `{character_split[2]}` is now being tracked.')
 

--- a/cogs/individuals.py
+++ b/cogs/individuals.py
@@ -209,7 +209,7 @@ class Individuals(commands.Cog):
             setcharacters_json = json.load(f)
 
         if str(ctx.message.author.id) in setcharacters_json.keys():
-            await ctx.send(f'Character `{setcharacters_json[str(ctx.message.author.id)]["character_name"]}` was previously set to this account. Overriding it...')
+            await ctx.send(f'Character `{setcharacters_json[str(ctx.message.author.id)]["character_name"]}` was previously linked to this account. Overriding it...')
         
         with open('./apiurl.txt', 'r') as f:
             api_url = constants.API_URL
@@ -229,7 +229,7 @@ class Individuals(commands.Cog):
         setcharacters_json[str(ctx.message.author.id)] = {'region': character_split[0], 'realm': character_split[1], 'character_name': character_split[2]}
         with open('./data/setcharacters.json', 'w') as f:
             json.dump(setcharacters_json, f)
-        await ctx.send(f'{ctx.message.author.mention}, character `{character_split[2]}` is now being tracked.')
+        await ctx.send(f'{ctx.message.author.mention}, character `{character_split[2]}` has now been linked to your account.')
 
 
 def setup(bot_client):

--- a/cogs/individuals.py
+++ b/cogs/individuals.py
@@ -24,7 +24,7 @@ class Individuals(commands.Cog):
         Sends out the score of the player
         """
 
-        realm, server, character_name = "", "", ""
+        region, realm, character_name = "", "", ""
         api_fields = ['mythic_plus_scores', 'mythic_plus_ranks', 'mythic_plus_best_runs', 'mythic_plus_alternate_runs']
 
         if args == "":
@@ -56,9 +56,9 @@ class Individuals(commands.Cog):
 
         # TODO: use message directly from API response instead of being hardcoded
         try:
-            assert r.status_code != 400, f"character `{character_name}` from `{server}` does not exist, perhaps you misspelled?"
+            assert r.status_code != 400, f"character `{character_name}` from `{realm}` does not exist, perhaps you misspelled?"
         except AssertionError:
-            await ctx.send(f"character `{character_name}` from `{server}` does not exist, perhaps you misspelled?")
+            await ctx.send(f"character `{character_name}` from `{realm}` does not exist, perhaps you misspelled?")
             raise
 
         request_json = r.json()
@@ -69,62 +69,66 @@ class Individuals(commands.Cog):
         char_role = self._convert_role(request_json['active_spec_role'])
         char_class = request_json['class']
         char_spec = request_json['active_spec_name']
+        char_thumbnail = request_json['thumbnail_url']
 
         # scores data
         char_total_score = request_json['mythic_plus_scores']['all']
         char_role_score = request_json['mythic_plus_scores'][char_role]
-        char_spec_score = request_json['mythic_plus_scores']['spec_0']
+        char_spec_score = request_json['mythic_plus_scores'][f'spec_{constants.spec_ids[char_class][char_spec]["id"]}']
 
         # rank data
-        char_role_rank = request_json['mythic_plus_ranks']['dps']
+        char_role_rank = request_json['mythic_plus_ranks'][char_role]
         char_class_rank = request_json['mythic_plus_ranks']['class']
-        char_spec_rank = request_json['mythic_plus_ranks'][f'spec_{constants.spec_ids[char_class][char_spec]}']
+        char_spec_rank = request_json['mythic_plus_ranks'][f'spec_{constants.spec_ids[char_class][char_spec]["uid"]}']
+
+        # TODO: de-duplicate dungeon data code
 
         # individual dungeon data
         best, nw_best, sd_best, halls_best, plaguefall_best, mists_best, spires_best, top_best, dos_best = request_json['mythic_plus_best_runs'], None, None, None, None, None, None, None, None
         for dungeon in best:
-            # breakpoint()
             if dungeon["dungeon"] == "The Necrotic Wake":
-                nw_best = dungeon["dungeon"]
+                nw_best = dungeon
             elif dungeon["dungeon"] == "Sanguine Depths":
-                sd_best = dungeon["dungeon"]
+                sd_best = dungeon
             elif dungeon["dungeon"] == "Spires of Ascension":
-                spires_best = dungeon["dungeon"]
+                spires_best = dungeon
             elif dungeon["dungeon"] == "Mists of Tirna Scithe":
-                mists_best = dungeon["dungeon"]
+                mists_best = dungeon
             elif dungeon["dungeon"] == "Halls of Atonement":
-                halls_best = dungeon["dungeon"]
+                halls_best = dungeon
             elif dungeon["dungeon"] == "Plaguefall":
-                pf_best = dungeon["dungeon"]
-            elif dungeon["dungeon"] == "Theatre of Pain":
-                top_best = dungeon["dungeon"]
+                pf_best = dungeon
+            elif dungeon["dungeon"] == "Theater of Pain":
+                top_best = dungeon
             elif dungeon["dungeon"] == "De Other Side":
-                dos_best = dungeon["dungeon"]
+                dos_best = dungeon
 
         # alternate dungeon data
         alt, nw_alt, sd_alt, halls_alt, plaguefall_alt, mists_alt, spires_alt, top_alt, dos_alt = request_json['mythic_plus_alternate_runs'], None, None, None, None, None, None, None, None
         for dungeon in alt:
             if dungeon["dungeon"] == "The Necrotic Wake":
-                nw_alt = dungeon["dungeon"]
+                nw_alt = dungeon
             elif dungeon["dungeon"] == "Sanguine Depths":
-                sd_alt = dungeon["dungeon"]
+                sd_alt = dungeon
             elif dungeon["dungeon"] == "Spires of Ascension":
-                spires_alt = dungeon["dungeon"]
+                spires_alt = dungeon
             elif dungeon["dungeon"] == "Mists of Tirna Scithe":
-                mists_alt = dungeon["dungeon"]
+                mists_alt = dungeon
             elif dungeon["dungeon"] == "Halls of Atonement":
-                halls_alt = dungeon["dungeon"]
+                halls_alt = dungeon
             elif dungeon["dungeon"] == "Plaguefall":
-                pf_alt = dungeon["dungeon"]
-            elif dungeon["dungeon"] == "Theatre of Pain":
-                top_alt = dungeon["dungeon"]
+                pf_alt = dungeon
+            elif dungeon["dungeon"] == "Theater of Pain":
+                top_alt = dungeon
             elif dungeon["dungeon"] == "De Other Side":
-                dos_alt = dungeon["dungeon"]
+                dos_alt = dungeon
 
-        character_embed = discord.Embed(title=f"{character_name}'s Raider.IO Profile", url=f"https://raider.io/characters/{realm}/{server}/{character_name}", 
+        character_embed = discord.Embed(title=f"{character_name}'s Raider.IO Profile", url=f"https://raider.io/characters/{region}/{realm}/{character_name}", 
             description="", color=discord.Color.blue()) # TODO: pair color with spec (shaman is blue, etc...)
 
         character_embed.set_author(name=f"Requested by {ctx.author.display_name}", icon_url=ctx.author.avatar_url)
+
+        character_embed.set_thumbnail(url=char_thumbnail)
 
         character_embed.add_field(name="Overall Statistics", value=f"**Total Score: {char_total_score}**\n", inline=False)
                                                                    # f"Tank Score: 0\n" +
@@ -135,12 +139,15 @@ class Individuals(commands.Cog):
                                                          f"Overall **{char_class}** Rank: Realm **#{char_class_rank['realm']}**, Region **#{char_class_rank['region']}**, World **#{char_class_rank['world']}**\n" +
                                                          f"Overall **{char_role}** Rank: Realm **#{char_role_rank['realm']}**, Region **#{char_role_rank['region']}**, World **#{char_role_rank['world']}**", inline=False)
 
-        # character_embed.add_field(name="**Best Dungeons**", value="\u200b", inline=False)
-
-        # character_embed.add_field(name="Dungeon Name", value="Mists of Tirna Scithe\nNW", inline=True)
-        # character_embed.add_field(name="Fortified", value="13\n15", inline=True)
-        # character_embed.add_field(name="Tyrannical", value="19\n11", inline=True)
-        # character_embed.add_field(name="Total Score", value="232.4\n101.3", inline=True)
+        # TODO: generalize this code with for loop and add cases for None best dungeons
+        character_embed.add_field(name="Best Dungeons", value=f"De Other Side - **{'+' * dos_best['num_keystone_upgrades']}{dos_best['mythic_level']}** {dos_best['affixes'][0]['name']}, Score: **{dos_best['score']:.1f}**\n" +
+                                                                  f"Halls of Atonement - **{'+' * halls_best['num_keystone_upgrades']}{halls_best['mythic_level']}** {halls_best['affixes'][0]['name']}, Score: **{halls_best['score']:.1f}**\n" +
+                                                                  f"Mists of Tirna Scithe - **{'+' * mists_best['num_keystone_upgrades']}{mists_best['mythic_level']}** {mists_best['affixes'][0]['name']}, Score: **{mists_best['score']:.1f}**\n" +
+                                                                  f"Necrotic Wake - **{'+' * nw_best['num_keystone_upgrades']}{nw_best['mythic_level']}** {nw_best['affixes'][0]['name']}, Score: **{nw_best['score']:.1f}**\n" +
+                                                                  f"Plaguefall - **{'+' * pf_best['num_keystone_upgrades']}{pf_best['mythic_level']}** {pf_best['affixes'][0]['name']}, Score: **{pf_best['score']:.1f}**\n" +
+                                                                  f"Sanguine Depths - **{'+' * sd_best['num_keystone_upgrades']}{sd_best['mythic_level']}** {sd_best['affixes'][0]['name']}, Score: **{sd_best['score']:.1f}**\n" +
+                                                                  f"Spires of Ascension - **{'+' * spires_best['num_keystone_upgrades']}{spires_best['mythic_level']}** {spires_best['affixes'][0]['name']}, Score: **{spires_best['score']:.1f}**\n" +
+                                                                  f"Theater of Pain - **{'+' * top_best['num_keystone_upgrades']}{top_best['mythic_level']}** {top_best['affixes'][0]['name']}, Score: **{top_best['score']:.1f}**\n", inline=False)
 
         await ctx.send(embed=character_embed)
 


### PR DESCRIPTION
**Patch description**
Added `setcharacter()` method to set a user's character as their default character. Included per dungeon statistics in player profile with appropriate bolding. Fixed Raider.IO link and healer/tanking rankings

**Testing steps**
Bot ran successfully. See screenshots:
<img width="1440" alt="Screen Shot 2021-08-26 at 5 51 34 PM" src="https://user-images.githubusercontent.com/7477689/131040939-c07b1e85-32ff-4772-976b-decd125f51e6.png">
<img width="1440" alt="Screen Shot 2021-08-26 at 5 51 58 PM" src="https://user-images.githubusercontent.com/7477689/131040988-1cd2a508-ca00-44ef-a341-f1ff4c9723af.png">
**Other information**
<!-- Any other information or context you would like to provide. -->
